### PR TITLE
Add Tolino Cloud Integration

### DIFF
--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -1,0 +1,60 @@
+FROM python:3.10-slim
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONIOENCODING=UTF-8 \
+    PIP_NO_CACHE_DIR=1 \
+    FLASK_PORT=8084 \
+    ENABLE_TOLINO=true \
+    TOLINO_WEBSHOP=hugendubel \
+    TOLINO_CREDENTIALS_FILE=/tmp/cwa-book-downloader/tolino_credentials.enc \
+    TOLINO_ENCRYPTION_KEY=tolino-integration-secret-key
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    chromium \
+    libxcursor1 \
+    libgtk-3-0 \
+    libnss3 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libpango-1.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libwayland-client0 \
+    libwayland-cursor0 \
+    libwayland-egl1 \
+    libxshmfence1 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create necessary directories
+RUN mkdir -p /app /var/log/cwa-book-downloader /tmp/cwa-book-downloader /cwa-book-ingest
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first to leverage Docker cache
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt && \
+    playwright install chromium
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE ${FLASK_PORT}
+
+# Run the application
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -28,8 +28,15 @@ The easiest way to run the application is using Docker and Docker Compose:
    ```
 
 3. Start the application using Docker Compose:
+
+   **Standard setup (with Tor support):**
    ```bash
    docker-compose up -d
+   ```
+
+   **Simplified setup (faster build):**
+   ```bash
+   docker-compose -f docker-compose-simple.yml up -d
    ```
 
 4. Access the application at http://localhost:8084

--- a/README.md
+++ b/README.md
@@ -12,13 +12,37 @@ This application allows you to search for books from various sources (primarily 
 
 ## Installation
 
-### Prerequisites
+### Option 1: Docker (Recommended)
+
+The easiest way to run the application is using Docker and Docker Compose:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/felixforfun/calibre-web-automated-book-downloader.git
+   cd calibre-web-automated-book-downloader
+   ```
+
+2. Create the necessary directories:
+   ```bash
+   mkdir -p /tmp/data/calibre-web/{ingest,tmp,logs}
+   ```
+
+3. Start the application using Docker Compose:
+   ```bash
+   docker-compose up -d
+   ```
+
+4. Access the application at http://localhost:8084
+
+### Option 2: Manual Installation
+
+#### Prerequisites
 
 - Python 3.8 or higher
 - Playwright for browser automation
 - Cryptography for secure credential storage
 
-### Setup
+#### Setup
 
 1. Clone the repository:
    ```bash
@@ -86,12 +110,37 @@ Your Tolino credentials are securely stored using encryption and are only used f
 
 ## Environment Variables
 
+### General Settings
+
 | Variable | Description | Default |
 |----------|-------------|---------|
-| ENABLE_TOLINO | Enable or disable Tolino integration | True |
-| TOLINO_WEBSHOP | Tolino webshop to use | hugendubel |
+| FLASK_PORT | Port for the web interface | 8084 |
+| LOG_LEVEL | Logging level (info, debug, warning, error) | info |
+| BOOK_LANGUAGE | Default language for book search | en |
+| USE_BOOK_TITLE | Use book title for filename | true |
+| TZ | Timezone | UTC |
+| APP_ENV | Application environment (prod, dev) | prod |
+| UID | User ID to run the application | 1000 |
+| GID | Group ID to run the application | 100 |
+
+### Tolino Integration Settings
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| ENABLE_TOLINO | Enable or disable Tolino integration | true |
+| TOLINO_WEBSHOP | Tolino webshop to use (hugendubel, thalia, weltbild, buecher, osiander, mayersche) | hugendubel |
 | TOLINO_CREDENTIALS_FILE | Path to store encrypted credentials | /tmp/cwa-book-downloader/tolino_credentials.enc |
 | TOLINO_ENCRYPTION_KEY | Key for encrypting credentials | tolino-integration-secret-key |
+
+### Docker Volumes
+
+When using Docker, you should mount the following volumes:
+
+| Volume | Description |
+|--------|-------------|
+| /cwa-book-ingest | Directory where downloaded books will be stored |
+| /tmp/cwa-book-downloader | Directory for temporary files and Tolino credentials |
+| /var/log/cwa-book-downloader | Directory for log files |
 
 ## Security Considerations
 

--- a/docker-compose-simple.yml
+++ b/docker-compose-simple.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  calibre-web-automated-book-downloader:
+    build:
+      context: .
+      dockerfile: Dockerfile.simple
+    container_name: calibre-web-automated-book-downloader
+    environment:
+      FLASK_PORT: 8084
+      LOG_LEVEL: info
+      BOOK_LANGUAGE: en
+      USE_BOOK_TITLE: true
+      TZ: America/New_York
+      APP_ENV: prod
+      UID: 1000
+      GID: 100
+      # Tolino integration settings
+      ENABLE_TOLINO: "true"
+      TOLINO_WEBSHOP: "hugendubel"
+      TOLINO_CREDENTIALS_FILE: "/tmp/cwa-book-downloader/tolino_credentials.enc"
+      TOLINO_ENCRYPTION_KEY: "tolino-integration-secret-key"
+    ports:
+      - 8084:8084
+    restart: unless-stopped
+    volumes:
+      # This is where the books will be downloaded to, usually it would be 
+      # the same as whatever you gave in "calibre-web-automated"
+      - /tmp/data/calibre-web/ingest:/cwa-book-ingest
+      # For Tolino credentials and temporary files
+      - /tmp/data/calibre-web/tmp:/tmp/cwa-book-downloader
+      # For logs
+      - /tmp/data/calibre-web/logs:/var/log/cwa-book-downloader

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
+version: '3.8'
+
 services:
   calibre-web-automated-book-downloader:
-    image: ghcr.io/calibrain/calibre-web-automated-book-downloader:latest
+    build:
+      context: .
+      target: cwa-bd
+    # Alternatively, use the pre-built image:
+    # image: ghcr.io/felixforfun/calibre-web-automated-book-downloader:latest
+    container_name: calibre-web-automated-book-downloader
     environment:
       FLASK_PORT: 8084
       LOG_LEVEL: info
@@ -10,10 +17,62 @@ services:
       APP_ENV: prod
       UID: 1000
       GID: 100
+      # Tolino integration settings
+      ENABLE_TOLINO: "true"
+      TOLINO_WEBSHOP: "hugendubel"
+      TOLINO_CREDENTIALS_FILE: "/tmp/cwa-book-downloader/tolino_credentials.enc"
+      TOLINO_ENCRYPTION_KEY: "tolino-integration-secret-key"
     ports:
       - 8084:8084
     restart: unless-stopped
     volumes:
-    # This is where the books will be downloaded to, usually it would be 
-    # the same as whatever you gave in "calibre-web-automated"
+      # This is where the books will be downloaded to, usually it would be 
+      # the same as whatever you gave in "calibre-web-automated"
       - /tmp/data/calibre-web/ingest:/cwa-book-ingest
+      # For Tolino credentials and temporary files
+      - /tmp/data/calibre-web/tmp:/tmp/cwa-book-downloader
+      # For logs
+      - /tmp/data/calibre-web/logs:/var/log/cwa-book-downloader
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8084/request/api/status"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Optional Tor service for anonymous browsing
+  calibre-web-automated-book-downloader-tor:
+    build:
+      context: .
+      target: cwa-bd-tor
+    # Alternatively, use the pre-built image:
+    # image: ghcr.io/felixforfun/calibre-web-automated-book-downloader:tor
+    container_name: calibre-web-automated-book-downloader-tor
+    environment:
+      FLASK_PORT: 8085
+      LOG_LEVEL: info
+      BOOK_LANGUAGE: en
+      USE_BOOK_TITLE: true
+      TZ: America/New_York
+      APP_ENV: prod
+      UID: 1000
+      GID: 100
+      USING_TOR: "true"
+      # Tolino integration settings
+      ENABLE_TOLINO: "true"
+      TOLINO_WEBSHOP: "hugendubel"
+      TOLINO_CREDENTIALS_FILE: "/tmp/cwa-book-downloader/tolino_credentials.enc"
+      TOLINO_ENCRYPTION_KEY: "tolino-integration-secret-key"
+    ports:
+      - 8085:8085
+    restart: unless-stopped
+    volumes:
+      - /tmp/data/calibre-web-tor/ingest:/cwa-book-ingest
+      - /tmp/data/calibre-web-tor/tmp:/tmp/cwa-book-downloader
+      - /tmp/data/calibre-web-tor/logs:/var/log/cwa-book-downloader
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8085/request/api/status"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 60s


### PR DESCRIPTION
This PR adds Tolino cloud integration to the calibre-web-automated-book-downloader application. It allows users to search for books, download them, and automatically upload them to their Tolino cloud account.

## Features

- Search for books using Anna's Archive API
- Download books to Calibre library
- Upload books to Tolino cloud (Hugendubel) using Playwright automation
- Secure credential storage with encryption
- Docker support for easy deployment
- Simplified Docker setup for faster builds

## How to Use

1. Set up the application using Docker or manual installation
2. Configure Tolino credentials in the UI
3. Search for books
4. Use the "Upload to Tolino" button to download and upload books in one step

## Environment Variables

- `ENABLE_TOLINO`: Enable/disable Tolino integration (default: true)
- `TOLINO_CREDENTIALS_FILE`: Path to store encrypted credentials
- `TOLINO_ENCRYPTION_KEY`: Key for encrypting credentials
- `TOLINO_WEBSHOP`: Tolino webshop to use (default: hugendubel)